### PR TITLE
Fix markdown page rendering

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,8 +223,10 @@ def mdpage(request: air.Request, slug: str):
     if path.exists():
         text = path.read_text()
         # TODO add fetching of page title from first H1 tag
+        # Wrap in air.Raw() because air-markdown's Markdown class overrides
+        # render() but Air uses _render() internally for child rendering
         return layout(
-            request, Markdown(text)
+            request, air.Raw(Markdown(text).render())
         )
     path = Path(f"pages/{slug}.py")
     if path.exists():


### PR DESCRIPTION
## Summary
- Fix /usage-policy page not rendering markdown as HTML
- Wrap `Markdown()` output in `air.Raw()` to work around air-markdown bug where `render()` is overridden but Air uses `_render()` internally

## Root cause
The `air-markdown` library's `Markdown` class overrides `render()` but Air's `BaseTag` uses `_render()` for the `html` property and `__str__`. When `Markdown` is used as a child of another tag, the markdown-to-HTML conversion was being skipped.

## Test plan
- [x] Visit http://127.0.0.1:8000/usage-policy and verify markdown renders as HTML