### PR TITLE
Update to air-markdown 0.5.0 with child rendering fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "air>=0.25.2",
-    "air-markdown>=0.2.1",
+    "air>=0.45.0",
+    "air-markdown>=0.5.0",
     "fastapi[standard]>=0.116.1",
 ]


### PR DESCRIPTION
## Summary
- Update air-markdown to >=0.5.0 which fixes Markdown rendering as child of another tag
- Update air to >=0.45.0 for consistency

## Context
This is an alternative to PR #8 which worked around the issue by wrapping `Markdown()` in `air.Raw()`. 

The root cause was in air-markdown: it overrode `render()` but Air 0.25+ renders child tags via `__str__` -> `html` property -> `_render()`. The fix in air-markdown 0.5.0 overrides `_render()` instead.

See: https://github.com/feldroy/AirMarkdown/pull/7

## Test plan
- [x] Visit http://127.0.0.1:8000/usage-policy and verify markdown renders as HTML (after air-markdown 0.5.0 is released)