### PR TITLE
Add deploy recipe for FastAPI Cloud

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,3 +50,7 @@ test *ARGS:
 pdb *ARGS:
     @echo "Running with arg: {{ARGS}}"
     uv run --python={{PY_VERSION}} --isolated --group test -- pytest --pdb --maxfail=10 {{ARGS}}
+
+# Deploy to FastAPI Cloud
+deploy:
+    uv run fastapi deploy


### PR DESCRIPTION
## Summary
- Add `just deploy` recipe for deploying to FastAPI Cloud

## Usage
```bash
just deploy
```

Runs `uv run fastapi deploy` which auto-detects the FastAPI app and deploys it.

## Reference
https://fastapicloud.com/docs/getting-started/